### PR TITLE
core: assert that port is an integer

### DIFF
--- a/lib/TransportRPCServer.js
+++ b/lib/TransportRPCServer.js
@@ -8,6 +8,8 @@ const assert = require('assert')
 
 class TransportRPCServer extends GrenacheWs.TransportRPCServer {
   listen (port) {
+    assert(Number.isInteger(port), 'port must be an Integer')
+
     this.listening()
 
     const socket = this.getSocket(port, this.conf)


### PR DESCRIPTION
 - avoids strange issues when the port is a String